### PR TITLE
Fixed meshing problems with gmsh

### DIFF
--- a/pycalculix/feamodel.py
+++ b/pycalculix/feamodel.py
@@ -1387,7 +1387,6 @@ class FeaModel(object):
             # mode setting
             if '*Node' in line or '*NODE' in line:
                 mode = 'nmake'
-                print('mode=nmake')
             elif '*Element' in line or '*ELEMENT' in line:
                 L = line.split(',') # split it based on commas
                 e = L[1].split('=')
@@ -1400,7 +1399,6 @@ class FeaModel(object):
                     set_type = 'E'
                     sets[set_type][set_name] = []
                     mode = 'emake'
-                    print('mode=emake')
                 else:
                     mode = None
             elif '*ELSET' in line:
@@ -1410,7 +1408,6 @@ class FeaModel(object):
                 set_type = 'E'
                 sets[set_type][set_name] = []
                 mode = 'set'
-                print('mode=set')
             elif '*NSET' in line:
                 L = line.split(',')
                 e = L[1].split('=')
@@ -1418,11 +1415,8 @@ class FeaModel(object):
                 set_type = 'N'
                 sets[set_type][set_name] = []
                 mode = 'set'
-                print('mode=set')
         f.close()
-
-        print('inputfile read')
-		
+        
         # loop through sets and remove empty sets
         # store sets to delete
         todel = []
@@ -1434,7 +1428,7 @@ class FeaModel(object):
         for adict in todel:
             (set_type, set_name) = (adict['set_type'], adict['set_name'])
             del sets[set_type][set_name]
-            print('Empty set type:%s name:%s deleted' % (set_type, set_name))
+            #print('Empty set type:%s name:%s deleted' % (set_type, set_name))
 
         # this resets the min element to number 1
         if E.get_minid() > 1:

--- a/pycalculix/geometry.py
+++ b/pycalculix/geometry.py
@@ -356,7 +356,7 @@ class Line(base_classes.Idobj):
         Args:
             ediv (int): number of required elements on this line
         """
-        print('Funktion ediv aufgerufen')
+        
         self.ediv = ediv
         self.pt(0).set_esize(self.length()/ediv)
         self.pt(1).set_esize(self.length()/ediv)
@@ -893,20 +893,20 @@ class Arc(base_classes.Idobj):
             point.save_line(self)
         
     def set_ediv(self, ediv):
-        """Sets the number of element divisions on the line when meshing.
+        """Sets the number of element divisions on the arc when meshing.
 
         Args:
-            ediv (int): number of required elements on this line
+            ediv (int): number of required elements on this arc
         """
         self.ediv = ediv
         self.pt(0).set_esize(self.length()/ediv)
         self.pt(1).set_esize(self.length()/ediv)
         
     def set_esize(self, esize):
-        """Sets the size of mesh elements on the line when meshing.
+        """Sets the size of mesh elements on the arc when meshing.
 
         Args:
-            esize (float): size of mesh elements on this line
+            esize (float): size of mesh elements on this arc
         """
         self.pt(0).set_esize(esize)
         self.pt(1).set_esize(esize)

--- a/pycalculix/geometry.py
+++ b/pycalculix/geometry.py
@@ -67,6 +67,7 @@ class Point(base_classes.Idobj):
         self.lines = []
         self.arc_center = False
         self.on_part = True
+        self.esize = None
         base_classes.Idobj.__init__(self)
 
     def get_name(self):
@@ -258,6 +259,10 @@ class Point(base_classes.Idobj):
         """Returns string listing object type, id number, and coordinates"""
         val = 'Point %s, (x, y)=(%.3f, %.3f)' % (self.get_name(), self.x, self.y)
         return val
+    
+    def set_esize(self, size):
+        self.esize = size
+        
 
 
 class Line(base_classes.Idobj):
@@ -351,7 +356,20 @@ class Line(base_classes.Idobj):
         Args:
             ediv (int): number of required elements on this line
         """
+        print('Funktion ediv aufgerufen')
         self.ediv = ediv
+        self.pt(0).set_esize(self.length()/ediv)
+        self.pt(1).set_esize(self.length()/ediv)
+        
+        
+    def set_esize(self, esize):
+        """Sets the size of mesh elements on the line when meshing.
+
+        Args:
+            esize (float): size of mesh elements on this line
+        """
+        self.pt(0).set_esize(esize)
+        self.pt(1).set_esize(esize)
 
     def signed_copy(self, sign):
         """Returns a SignLine copy of this Line with the passed sign."""
@@ -675,7 +693,11 @@ class SignLine(Line, base_classes.Idobj):
     def set_ediv(self, ediv):
         """Applies the element divisions onto the parent line."""
         self.line.set_ediv(ediv)
-
+        
+    def set_esize(self, esize):
+        """Applies the element size onto the parent line."""
+        self.line.set_esize(esize)
+        
     def set_lineloop(self, lineloop):
         """Sets the parent LineLoop"""
         # this is needed to cascade set ediv up to FEA model and down onto
@@ -869,15 +891,26 @@ class Arc(base_classes.Idobj):
         """This stores this line in the line's child points."""
         for point in self.allpoints:
             point.save_line(self)
-
+        
     def set_ediv(self, ediv):
-        """Sets the number of element divisions on the arc when meshing.
+        """Sets the number of element divisions on the line when meshing.
 
         Args:
-            ediv (int): number of required elements on this arc
+            ediv (int): number of required elements on this line
         """
         self.ediv = ediv
+        self.pt(0).set_esize(self.length()/ediv)
+        self.pt(1).set_esize(self.length()/ediv)
+        
+    def set_esize(self, esize):
+        """Sets the size of mesh elements on the line when meshing.
 
+        Args:
+            esize (float): size of mesh elements on this line
+        """
+        self.pt(0).set_esize(esize)
+        self.pt(1).set_esize(esize)
+        
     def signed_copy(self, sign):
         """Returns a SignArc instance of this Arc with the passed sign."""
         return SignArc(self, sign)


### PR DESCRIPTION
- meshing with transfinite line lead to bad meshes in the intersection between lines
- line next to transfinite line was not affected by mesh size changes (easy to see in dam.py example with fine mesh)
- I changed mesh size definition to 'element size at point'
- added function 'set_esize' to define element size instead of numbers
- meshing should also be more stable with this
- the same size definition lead to quad elements be half the size of tri elements, added simple fix for this in __mesh__gmsh function