### PR TITLE
removed exerimental gmsh flag Mesh.CharacteristicLengthFromCurvature

### DIFF
--- a/pycalculix/feamodel.py
+++ b/pycalculix/feamodel.py
@@ -1779,7 +1779,8 @@ class FeaModel(object):
         geo.append('Mesh.CharacteristicLengthMin = 0;')
         geo.append('Mesh.CharacteristicLengthMax = 1e+022;')
         # use this so small circles are meshed finely
-        geo.append('Mesh.CharacteristicLengthFromCurvature = 1;')
+        # this is broken in Gmsh 4.3.0
+        # geo.append('Mesh.CharacteristicLengthFromCurvature = 1;')
         geo.append('Mesh.CharacteristicLengthFromPoints = 1;')
         # geo.append('Mesh.Algorithm = 2; //delauny') #okay for quads
         geo.append('Mesh.Algorithm = 8; //delquad = delauny for quads')


### PR DESCRIPTION
I like your project.  I used to contribute to CalculiX and used it with Gmsh often.  They are great tools.

I was playing around with pycalculix and noticed that the `mesh.CharacteristicLengthFromCurvature` flag that you are adding to the GEO files fails in the current version of Gmsh (4.3.0) with the example problem `hole-in-plate-full.py`.  This is an experimental option according to the Gmsh docs, so it may be good to try to work without it.