### PR TITLE
Getting KeyError: 'ERROR' when running hole-in-plate-quarter - fixes #56

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ junit/
 *.12d
 *.cvg
 *.dat
-*.frd
 *.geo
 *.inp
 *.msh

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,13 @@ __pycache__
 # tests
 .pytest_cache
 junit/
+*.12d
+*.cvg
+*.dat
+*.frd
+*.geo
+*.inp
+*.msh
+*.sta
+*.png
+*.ipynb

--- a/pycalculix/base_classes.py
+++ b/pycalculix/base_classes.py
@@ -25,6 +25,7 @@ RESFIELDS['displ'] = 'ux,uy,uz,utot'.split(',')
 RESFIELDS['stress'] = 'Sx,Sy,Sz,Sxy,Syz,Szx,Seqv,S1,S2,S3'.split(',')
 RESFIELDS['strain'] = 'ex,ey,ez,exy,eyz,ezx,eeqv,e1,e2,e3'.split(',')
 RESFIELDS['force'] = 'fx,fy,fz'.split(',')
+RESFIELDS['error'] = 'STR(%)'.split(',')
 
 #FIELDTYPE is a dict that inverts the RESFIELDS dictionary mapping.
 FIELDTYPE = {}

--- a/pycalculix/base_classes.py
+++ b/pycalculix/base_classes.py
@@ -8,11 +8,13 @@ Attributes:
             - 'stress': stress
             - 'strain': strain
             - 'force': force
+            - 'error': FE discretization error in stress
         value (list):
             - 'displ' = 'ux','uy','uz','utot'
             - 'stress' = 'Sx','Sy','Sz','Sxy','Syz','Szx','Seqv','S1','S2','S3'
             - 'strain' = 'ex','ey','ez','exy','eyz','ezx','eeqv','e1','e2','e3'
             - 'force' = 'fx','fy','fz'
+            = 'error' = 'STR(%)'
     FIELDTYPE (dict): the inverse dict of RESFIELDS
 
         For example: key 'ux' --> value: 'displ'
@@ -25,7 +27,7 @@ RESFIELDS['displ'] = 'ux,uy,uz,utot'.split(',')
 RESFIELDS['stress'] = 'Sx,Sy,Sz,Sxy,Syz,Szx,Seqv,S1,S2,S3'.split(',')
 RESFIELDS['strain'] = 'ex,ey,ez,exy,eyz,ezx,eeqv,e1,e2,e3'.split(',')
 RESFIELDS['force'] = 'fx,fy,fz'.split(',')
-RESFIELDS['error'] = 'STR(%)'.split(',')
+RESFIELDS['error'] = ['STR(%)']
 
 #FIELDTYPE is a dict that inverts the RESFIELDS dictionary mapping.
 FIELDTYPE = {}

--- a/pycalculix/results_file.py
+++ b/pycalculix/results_file.py
@@ -1018,7 +1018,8 @@ class ResultsFile(object):
         mode_by_name = {'DISP': 'displ',
                         'STRESS': 'stress',
                         'TOSTRAIN': 'strain',
-                        'FORC': 'force'}
+                        'FORC': 'force',
+                        'ERROR': 'error'}
         mode = mode_by_name[name]
         print('Reading '+mode+' storing: '+
               ','.join(base_classes.RESFIELDS[mode]))
@@ -1073,6 +1074,16 @@ class ResultsFile(object):
         node, f_x, f_y, f_z = self.__get_vals(rfstr, line)[1:]
         labs = base_classes.RESFIELDS[mode]
         vals = [f_x, f_y, f_z]
+        adict = self.__results[time]['node'][node]
+        for (label, val) in zip(labs, vals):
+            adict[label] = val
+
+    def _save_node_error(self, line, rfstr, time, mode='error'):
+        """Saves node error"""
+        # [key, node, error]
+        node, error = self.__get_vals(rfstr, line)[1:]
+        labs = base_classes.RESFIELDS[mode]
+        vals = [error]
         adict = self.__results[time]['node'][node]
         for (label, val) in zip(labs, vals):
             adict[label] = val

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -46,7 +46,13 @@ class TestExamples(unittest.TestCase):
                 for line in ex.output.splitlines():
                     print(line)
             raise ex
-
+            
+    def example_load_results(self, file_name):
+        proj_name = os.path.join('examples', file_name)
+        model = pyc.FeaModel(proj_name)
+        prob = pyc.Problem(model, 'struct')
+        prob.rfile.load()
+        
     def test_compr_rotor(self, file_name='compr-rotor.py'):
         self.example_tester(file_name)
 
@@ -64,6 +70,9 @@ class TestExamples(unittest.TestCase):
 
     def test_hole_full(self, file_name='hole-in-plate-full.py'):
         self.example_tester(file_name)
+        
+    def test_hole_full_load_result(self, file_name='hole-in-plate-full-from-ccx-ver2-16.frd'):
+        self.example_load_results(file_name)
 
     def test_hole_quarter(self, file_name='hole-in-plate-quarter.py'):
         self.example_tester(file_name)
@@ -104,7 +113,7 @@ class TestExamples(unittest.TestCase):
         self.example_tester(file_name)
 
     def test_rounded_square_cw(self,
-                               file_name='rounded-square-cw.py'):
+                                file_name='rounded-square-cw.py'):
         self.example_tester(file_name)
 
 


### PR DESCRIPTION
This PR solves the issue #56 by adding a new result data field. ccx solves for the error from each node and captures this in the results file (i.e. .frd file) which pycalculix `solve` function in `problem.py` would not understand. Therefore, I added a new mode and mode name with associated functions to make the results from the new mode be accessible.